### PR TITLE
export compose function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export compose from './compose.js';
 export * from './utils';
 export { mod, set } from './lens-consumers/setters.js';
 export { get } from './lens-consumers/getters.js';


### PR DESCRIPTION
compose is not exported, but I think it would be helpful to have available for building custom lenses.

In my case, I am using custom lenses to build database queries. I have a prop lens, and also a path that is the composition of multiple props. Since I cannot just use default compiled props, I end up with get(prop('one'), prop('two'), /*...*/) so it's nicer to compose them behind the scenes: get(path('one', 'two'), /*...*/))